### PR TITLE
fix: Octal in strict mode

### DIFF
--- a/lib/node/formatters/npm.js
+++ b/lib/node/formatters/npm.js
@@ -1,4 +1,4 @@
-var Transform = require('../../common/transform.js');
+var Transform = require("../../common/transform.js");
 
 function FormatNpm() {}
 
@@ -6,14 +6,17 @@ Transform.mixin(FormatNpm);
 
 FormatNpm.prototype.write = function(name, level, args) {
   var out = {
-        debug: '\033[34;40m' + 'debug' + '\033[39m ',
-        info: '\033[32m' + 'info'  + '\033[39m  ',
-        warn: '\033[30;41m' + 'WARN' + '\033[0m  ',
-        error: '\033[31;40m' + 'ERR!' + '\033[0m  '
-      };
-  this.emit('item', (name ? '\033[37;40m'+ name +'\033[0m ' : '')
-          + (level && out[level]? out[level] : '')
-          + args.join(' '));
+    debug: "\x1B[34;40m" + "debug" + "\x1B[39m ",
+    info: "\x1B[32m" + "info" + "\x1B[39m  ",
+    warn: "\x1B[30;41m" + "WARN" + "\x1B[0m  ",
+    error: "\x1B[31;40m" + "ERR!" + "\x1B[0m  "
+  };
+  this.emit(
+    "item",
+    (name ? "\x1B[37;40m" + name + "\x1B[0m " : "") +
+      (level && out[level] ? out[level] : "") +
+      args.join(" ")
+  );
 };
 
 module.exports = FormatNpm;

--- a/lib/node/formatters/util.js
+++ b/lib/node/formatters/util.js
@@ -1,25 +1,24 @@
 var styles = {
-    //styles
-    'bold'      : ['\033[1m',  '\033[22m'],
-    'italic'    : ['\033[3m',  '\033[23m'],
-    'underline' : ['\033[4m',  '\033[24m'],
-    'inverse'   : ['\033[7m',  '\033[27m'],
-    //grayscale
-    'white'     : ['\033[37m', '\033[39m'],
-    'grey'      : ['\033[90m', '\033[39m'],
-    'black'     : ['\033[30m', '\033[39m'],
-    //colors
-    'blue'      : ['\033[34m', '\033[39m'],
-    'cyan'      : ['\033[36m', '\033[39m'],
-    'green'     : ['\033[32m', '\033[39m'],
-    'magenta'   : ['\033[35m', '\033[39m'],
-    'red'       : ['\033[31m', '\033[39m'],
-    'yellow'    : ['\033[33m', '\033[39m']
-  };
+  //styles
+  bold: ["\x1B[1m", "\x1B[22m"],
+  italic: ["\x1B[3m", "\x1B[23m"],
+  underline: ["\x1B[4m", "\x1B[24m"],
+  inverse: ["\x1B[7m", "\x1B[27m"],
+  //grayscale
+  white: ["\x1B[37m", "\x1B[39m"],
+  grey: ["\x1B[90m", "\x1B[39m"],
+  black: ["\x1B[30m", "\x1B[39m"],
+  //colors
+  blue: ["\x1B[34m", "\x1B[39m"],
+  cyan: ["\x1B[36m", "\x1B[39m"],
+  green: ["\x1B[32m", "\x1B[39m"],
+  magenta: ["\x1B[35m", "\x1B[39m"],
+  red: ["\x1B[31m", "\x1B[39m"],
+  yellow: ["\x1B[33m", "\x1B[39m"]
+};
 
 exports.levelMap = { debug: 1, info: 2, warn: 3, error: 4 };
 
 exports.style = function(str, style) {
   return styles[style][0] + str + styles[style][1];
-}
-
+};


### PR DESCRIPTION
Octal are not supported in strict mode. We have to convert it to hexa. 

Now it works out of the box without editing our babel config to run our test suite on drive 