### PR TITLE
chore: add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "license": "MIT",
   "version": "3.1.0",
   "main": "lib/index.js",
+  "files": [
+    "/dist",
+    "/lib"
+  ],
   "dependencies": {
     "microee": "0.0.6"
   },


### PR DESCRIPTION
npm doesn't install correctly the package when using a URL because of the symlink in the test folder (npm ERR! premature close).
Not adding the test folder in files prevent the issue.